### PR TITLE
Remove draw observer

### DIFF
--- a/Plum.roboFontExt/lib/plum/observer.py
+++ b/Plum.roboFontExt/lib/plum/observer.py
@@ -7,7 +7,6 @@ class PlumObserver(object):
 
     def __init__(self):
         addObserver(self, 'update', 'currentGlyphChanged')
-        addObserver(self, 'update', 'draw')
 
     def update(self, info):
         Plum(info['glyph']).update()

--- a/Plum.roboFontExt/lib/plum/plum.py
+++ b/Plum.roboFontExt/lib/plum/plum.py
@@ -11,16 +11,15 @@ class Plum(object):
             self.destroy()
         else:
             self.create()
+        self.update()
 
     def create(self):
         if self.glyph_exists:
             self.glyph.addGuide(self.position, self.angle, name=GUIDE_NAME)
-            self.update()
 
     def destroy(self):
         if self.glyph_exists:
             self.glyph.removeGuide(self.plum_guide)
-            self.update()
 
     def update(self):
         if self.glyph_exists:

--- a/Plum.roboFontExt/lib/plum/plum.py
+++ b/Plum.roboFontExt/lib/plum/plum.py
@@ -15,10 +15,12 @@ class Plum(object):
     def create(self):
         if self.glyph_exists:
             self.glyph.addGuide(self.position, self.angle, name=GUIDE_NAME)
+            self.update()
 
     def destroy(self):
         if self.glyph_exists:
             self.glyph.removeGuide(self.plum_guide)
+            self.update()
 
     def update(self):
         if self.glyph_exists:


### PR DESCRIPTION
Plum slowed down my entire user interface. Problem disappeared after removing the draw observer and adding a `self.update()` call to the toggle method.
